### PR TITLE
Clarify the use of python2's virtualenv package

### DIFF
--- a/utils/run.cmd
+++ b/utils/run.cmd
@@ -10,7 +10,7 @@ if exist %VIRTUALENV% (
     echo [+] Using existing virtualenv.
 ) ELSE (
     echo [+] Creating virtualenv...
-    call virtualenv %VIRTUALENV% > nul
+    call python -mvirtualenv %VIRTUALENV% > nul
 )
 
 call %VIRTUALENV%\Scripts\activate

--- a/utils/run.sh
+++ b/utils/run.sh
@@ -8,7 +8,7 @@ if [ -d "$VIRTUALENV" ]; then
     echo "[+] Using existing virtualenv."
 else
     echo "[+] Creating virtualenv..."
-    virtualenv "$VIRTUALENV" > /dev/null
+    python2 -mvirtualenv "$VIRTUALENV" > /dev/null
 fi
 
 . "$VIRTUALENV/bin/activate"


### PR DESCRIPTION
When multiple python versions (and therefore virtualenv-packages) this clarifies to use the python 2.7 virtualenv.
Possible would also be `python -mvirtualenv`, but `virtualenv` alone can also run the one for python3 in some cases.