### PR TITLE
Added a "http_proxy" setting to the VirusTotal download module

### DIFF
--- a/utils/initial_data.py
+++ b/utils/initial_data.py
@@ -95,8 +95,14 @@ def create_virustotal_configuration():
                     'description': 'VirusTotal Intelligence API key.',
                     'type': 'str',
                     'value': None
-                }
-            ]})
+                },
+                {
+                    'name': 'http_proxy',
+                    'description': 'HTTP Proxy Server (http://<host>:<port>)',
+                    'type': 'str',
+                    'default': '',
+                    'value': None
+                }]})
 
         vt.save()
 

--- a/utils/update_virustotal_config.py
+++ b/utils/update_virustotal_config.py
@@ -1,0 +1,17 @@
+#
+# Adds an extra configuration parameter to the VirusTotal settings in 
+# the Mongo database.  This setting allows an http proxy to be used.
+#
+
+import os
+import sys
+
+sys.path.append(os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..")))
+
+from fame.core.config import Config
+
+vt = Config.get(name='virustotal')
+if vt and vt.has_key('config'):
+    vt['config'].append({'type': 'str', 'default' : '', 'name':'http_proxy', 'value': None, 'description': 'Optional: HTTP Proxy Server (http://<host>:<port>)'})
+vt.save()
+

--- a/web/views/analyses.py
+++ b/web/views/analyses.py
@@ -179,7 +179,11 @@ class AnalysesView(FlaskView, UIView):
                     config = config.get_values()
 
                     params = {'apikey': config.api_key, 'hash': hash}
-                    response = requests.get('https://www.virustotal.com/vtapi/v2/file/download', params=params)
+                    proxies = {}
+                    if config.http_proxy is not None and config.http_proxy != "":
+                        proxies = { "http": config.http_proxy, "https": config.http_proxy }
+
+                    response = requests.get('https://www.virustotal.com/vtapi/v2/file/download', params=params, proxies=proxies)
                     if response.status_code == 403:
                         flash('This requires a valid API key.', 'danger')
                     elif response.status_code == 404:


### PR DESCRIPTION
In my environment, we are required to access VirusTotal through a proxy.  This patch adds a configuration setting for VirusTotal proxy and then checks for it when downloading files.

The 'utils/update_virustotal_config.py' inserts the new setting into the Mongo database.  I'm not sure how you typically handle these changes.

Please let me know if you want something reworked.  Thanks!  -- Matt