### PR TITLE
Fixed MongoDB authentication. Closes #29

### DIFF
--- a/fame/core/store.py
+++ b/fame/core/store.py
@@ -14,7 +14,9 @@ class Store:
         # Connection
         self._con = MongoClient(fame_config.mongo_host, int(fame_config.mongo_port), serverSelectionTimeoutMS=10000)
         self.db = self._con[fame_config.mongo_db]
-
+        if fame_config.mongo_user and fame_config.mongo_password:
+            self.db.authenticate(fame_config.mongo_user, quote_plus(fame_config.mongo_password), mechanism='SCRAM-SHA-1')
+            
         # Collections
         self.files = self.db.files
         self.analysis = self.db.analysis
@@ -32,9 +34,6 @@ class Store:
 
     def connect(self):
         self.init()
-
-        if fame_config.mongo_user and fame_config.mongo_password:
-            self.db.authenticate(fame_config.mongo_user, quote_plus(fame_config.mongo_password), mechanism='SCRAM-SHA-1')
 
         # Create indexes
         self.files.create_index('md5')


### PR DESCRIPTION
Reproduction example:
- MongoDB with authentication enabled
- Run: utils/run.sh utils/troubleshoot.py
- Output:
(...)
########## Configuration ##########

Traceback (most recent call last):
  File "utils/troubleshoot.py", line 84, in <module>
    main()
  File "utils/troubleshoot.py", line 81, in main
    configuration()
  File "utils/troubleshoot.py", line 59, in configuration
    for config in Config.find():
  File "/opt/fame/fame/fame/common/mongo_dict.py", line 24, in find
    for obj in objs:
  File "/opt/fame/fame/env/local/lib/python2.7/site-packages/pymongo/cursor.py", line 1176, in next
    if len(self.__data) or self._refresh():
  File "/opt/fame/fame/env/local/lib/python2.7/site-packages/pymongo/cursor.py", line 1087, in _refresh
    self.__send_message(q)
  File "/opt/fame/fame/env/local/lib/python2.7/site-packages/pymongo/cursor.py", line 974, in __send_message
    helpers._check_command_response(first)
  File "/opt/fame/fame/env/local/lib/python2.7/site-packages/pymongo/helpers.py", line 146, in _check_command_response
    raise OperationFailure(msg % errmsg, code, response)
pymongo.errors.OperationFailure: not authorized on fame to execute command { find: "settings", filter: {} }