### PR TITLE
enable auto reload of changed Jinja2 templates

### DIFF
--- a/webserver.py
+++ b/webserver.py
@@ -27,6 +27,7 @@ except:
 
 app = Flask(__name__, template_folder='web/templates', static_folder='web/static')
 app.secret_key = fame_config.secret_key
+app.config['TEMPLATES_AUTO_RELOAD'] = True
 
 # Set two tempalte folders (one is for modules)
 template_loader = jinja2.ChoiceLoader([


### PR DESCRIPTION
### Description
If one updates the content of any HTML template which was already loaded by FAME, the web application ignores the changed template and keeps rendering the old template (because of Jinja2's internal caching). This situation may occur if one of the modules updates its `details.html` file.

### Steps to Reproduce
Change any of the HTML templates which is used by FAME (e.g. web/templates/base.html).

#### Expected behavior
The web application should reload the changed template and show the updated HTML.

#### Actual behavior
The web application ignores the changed template until it is reloaded/restarted.

#### Proposed Fix
The proposed fix enables the auto-reload feature of Jinja2 (cf. http://flask.pocoo.org/docs/1.0/config/#TEMPLATES_AUTO_RELOAD).