### PR TITLE
fix 'add_extracted_file' exceptions (#61)

### DIFF
--- a/fame/core/analysis.py
+++ b/fame/core/analysis.py
@@ -4,6 +4,7 @@ import datetime
 from shutil import copy
 from hashlib import md5
 from urlparse import urljoin
+from bson import json_util
 
 from fame.common.config import fame_config
 from fame.common.utils import iterify, u, send_file_to_remote
@@ -88,7 +89,7 @@ class Analysis(MongoDict):
         if not f.existing:
             if fame_config.remote:
                 response = send_file_to_remote(filepath, '/files/')
-                f = File(response.json()['file'])
+                f = File(json_util.loads(response.text)['file'])
             else:
                 f = File(filename=os.path.basename(filepath), stream=fd)
 

--- a/web/views/files.py
+++ b/web/views/files.py
@@ -8,7 +8,7 @@ from werkzeug.utils import secure_filename
 from fame.core.store import store
 from fame.core.file import File
 from fame.core.module_dispatcher import dispatcher
-from web.views.negotiation import render
+from web.views.negotiation import render, render_json
 from web.views.constants import PER_PAGE
 from web.views.helpers import file_download, get_or_404, requires_permission, clean_files, clean_analyses, clean_users
 from web.views.mixins import UIView
@@ -119,7 +119,7 @@ class FilesView(FlaskView, UIView):
         file = request.files['file']
         f = File(filename=secure_filename(file.filename), stream=file.stream)
 
-        return render({'file': f})
+        return render_json({'file': f})
 
     def download(self, id):
         """Download the file with `id`.


### PR DESCRIPTION
Fixes #61 by
* enforcing a JSON encoded response after POSTing to `/files/` (`web/views/file.py:122`) and
* properly decoding the returned JSONified Mongo object of the `File` class so that it can be processed further (`fame/core/analysis.py:96`). 

The explicit decode by `bson.json_utils.loads` is needed because PyMongo otherwise cannot correctly map this file object to a database object (the `_id` field is a `dict` in pure JSON but needs to parsed into a `ObjectId` as indicated by the `$oid` key: `{"_id": {"$oid": "<id of object in database>"}, ...`).