### PR TITLE
Fix for no visible attachments / text body when sending emails

### DIFF
--- a/fame/common/email_utils.py
+++ b/fame/common/email_utils.py
@@ -68,7 +68,7 @@ class EmailMessage:
     def __init__(self, server, subject):
         self.server = server
 
-        self.msg = MIMEMultipart('alternative')
+        self.msg = MIMEMultipart()
         self.msg['Subject'] = subject
         self.msg['From'] = server.config.from_address
         self.msg['Reply-to'] = server.config.replyto or server.config.from_address
@@ -83,11 +83,16 @@ class EmailMessage:
             filename = os.path.basename(filepath)
 
         with open(filepath, "rb") as f:
+            '''
             self.msg.attach(MIMEApplication(
                 f.read(),
                 Content_Disposition='attachment; filename="{}"'.format(filename),
                 Name=filename
             ))
+            '''
+            part = MIMEApplication(f.read(), Name=os.path.basename(filepath))
+            part['Content-Disposition'] = 'attachment; filename="{0}"'.format(filename)
+            self.msg.attach(part)            
 
     def send(self, to, cc=[], bcc=[]):
         recipients = to + cc + bcc


### PR DESCRIPTION
### Description
Hi, I am developing a simple reporting plugin and have encountered some problems while sending emails. For example, the zipped files are not showing as attachment, nor the text body. 

### Steps to Reproduce
* Use a Antivir Module (like McAfee) and modify the mailing address in the code with your own email address:
```
class McAfee(MailSubmission):
    name = "McAfee"
    description = "Submit the file to McAfee for inclusion in detections."

    mail_submission = "johndoe@mydomain.com"
```
* Or use the mailing class/configuration from FAME in your plugin:
```
from fame.common.email_utils import EmailMixin, EmailServer
...
        server = EmailServer()
        msg = server.new_message(subject), mailbody)
        msg.add_attachment(attachment)
        msg.send([self.sender])  
```
#### Expected behavior
Zipped files showed as attachment (clip symbol) and text body visible.

#### Actual behavior
No attachment or body text visible. You have to open the message and view the sources

### Debug
Using the default code of email_utils.py:
https://github.com/certsocietegenerale/fame/blob/master/fame/common/email_utils.py
```
class EmailMessage:
    def __init__(self, server, subject):
....
        self.msg = MIMEMultipart('alternative')
...
```
The received email source was:

> --===============8280141680987609642==
> Content-Type: text/text; charset="utf-8"
> Content-Transfer-Encoding: base64
> 
> --===============8280141680987609642==
> Content-Type: application/octet-stream; content-disposition="attachment;
>  filename=\"report_5d417207019ba90f587cbb36.zip\"";
> 	name="report_5d417207019ba90f587cbb36.zip"
> Content-Transfer-Encoding: base64

Note that there isn't any "Content-Disposition", so it seems there is a problem in "add_attachment()"

### Workaround
Use "MIMEMultipart()" instead of "MIMEMultipart('alternative')" and these modifications in "add_attachment()":

        with open(filepath, "rb") as f:
            part = MIMEApplication(f.read(), Name=os.path.basename(filepath))
            part['Content-Disposition'] = 'attachment; filename="{0}"'.format(filename)
            self.msg.attach(part)


 I am still testing it but seems to work.

`        self.msg = MIMEMultipart()
`

The received email source (with different analysis):

> --===============8650156058168977947==
> Content-Type: text/text; charset="utf-8"; name="ATT00001"
> Content-Transfer-Encoding: base64
> Content-Description: ATT00001
> Content-Disposition: attachment; filename="ATT00001"
> 
> UmVwb3J0IG9mIDVkNDE4NzcxMDE5YmE5MjBjYTBmZDFjNCBhbmFseXNpcyBpcyBhdHRhY2hlZA==
> 
> --===============8650156058168977947==
> Content-Type: application/octet-stream;
> 	name="report_5d418771019ba920ca0fd1c4.zip"
> Content-Transfer-Encoding: base64
> Content-Disposition: attachment;
> 	filename="report_5d418771019ba920ca0fd1c4.zip"
> Content-Description: report_5d418771019ba920ca0fd1c4.zip