### PR TITLE
Refactor remote worker module download for Python3

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -5,7 +5,7 @@ import argparse
 import requests
 from urllib.parse import urljoin
 from socket import gethostname
-from io import StringIO
+from io import BytesIO
 from zipfile import ZipFile
 from shutil import move, rmtree
 from uuid import uuid4
@@ -51,7 +51,7 @@ class Worker:
                 response.raise_for_status()
 
                 os.makedirs(MODULES_ROOT)
-                with ZipFile(StringIO(response.content), 'r') as zipf:
+                with ZipFile(BytesIO(response.content), 'r') as zipf:
                     zipf.extractall(MODULES_ROOT)
 
                 rmtree(backup_path)


### PR DESCRIPTION
In Python3 there is a change in return from requests.
During the download of the zipfile form the master the worker expect a str but due to this change requests return a byte failing the module installation on remote workers
With this refactor the remote worker can unzip a stream of byte matching the return of requests