### PR TITLE
use URL and scheme defined in fame config

### DIFF
--- a/web/auth/ad/views.py
+++ b/web/auth/ad/views.py
@@ -1,5 +1,7 @@
 from flask import Blueprint, render_template, request, redirect, flash
 from flask_login import logout_user
+from fame.common.config import fame_config
+from urllib.parse import urljoin
 
 from web.views.helpers import prevent_csrf, user_has_groups_and_sharing
 from web.auth.ad.user_management import authenticate, LdapSettingsNotPresentException
@@ -33,10 +35,10 @@ def login():
             return render_template('login.html')
 
         redir = request.args.get('next', '/')
-        return redirect(redir)
+        return redirect(urljoin(fame_config.fame_url, redir))
 
 
 @auth.route('/logout')
 def logout():
     logout_user()
-    return redirect('/login')
+    return redirect(urljoin(fame_config.fame_url, '/login'))

--- a/web/auth/single_user/views.py
+++ b/web/auth/single_user/views.py
@@ -1,5 +1,7 @@
 from flask_login import login_user
 from flask import Blueprint, request, redirect
+from fame.common.config import fame_config
+from urllib.parse import urljoin
 
 from fame.core.user import User
 from web.views.helpers import prevent_csrf
@@ -36,10 +38,10 @@ def login():
 
     login_user(get_or_create_user())
 
-    return redirect(redir)
+    return redirect(urljoin(fame_config.fame_url, redir))
 
 
 @auth.route('/logout')
 def logout():
     redir = '/'
-    return redirect(redir)
+    return redirect(urljoin(fame_config.fame_url, redir))

--- a/web/auth/user_password/views.py
+++ b/web/auth/user_password/views.py
@@ -76,12 +76,12 @@ def password_reset_form():
                     msg.send([user['email']])
 
                 flash('A password reset link was sent.')
-                return redirect('/login')
+                return redirect(urljoin(fame_config.fame_url, '/login'))
 
         return render_template('password_reset_form.html')
     else:
         flash('Functionnality unavailable. Contact your administrator', 'danger')
-        return redirect('/login')
+        return redirect(urljoin(fame_config.fame_url, '/login'))
 
 
 @auth.route('/password_reset/<token>', methods=['GET', 'POST'])
@@ -91,10 +91,10 @@ def password_reset(token):
         user_id = validate_password_reset_token(token)
     except BadTimeSignature:
         flash('Invalid token', 'danger')
-        return redirect('/login')
+        return redirect(urljoin(fame_config.fame_url, '/login'))
     except SignatureExpired:
         flash('Expired token', 'danger')
-        return redirect('/login')
+        return redirect(urljoin(fame_config.fame_url, '/login'))
 
     if request.method == 'POST':
         password = request.form.get('password', '')
@@ -104,7 +104,7 @@ def password_reset(token):
             user = User(get_or_404(User.get_collection(), _id=user_id.decode('ascii')))
             change_password(user, password)
             flash('Password was successfully changed.', 'success')
-            return redirect('/login')
+            return redirect(urljoin(fame_config.fame_url, '/login'))
 
     return render_template('password_reset.html')
 
@@ -117,7 +117,7 @@ def login():
     else:
         if authenticate(request.form.get('email'), request.form.get('password')):
             redir = request.args.get('next', '/')
-            return redirect(redir)
+            return redirect(urljoin(fame_config.fame_url, redir))
         else:
             flash("Invalid credentials.", "danger")
             return render_template('login.html')
@@ -126,7 +126,7 @@ def login():
 @auth.route('/logout')
 def logout():
     logout_user()
-    return redirect('/login')
+    return redirect(urljoin(fame_config.fame_url, '/login'))
 
 
 @auth.route('/change_password', methods=['POST'])

--- a/webserver.py
+++ b/webserver.py
@@ -9,6 +9,7 @@ from flask_login import LoginManager
 from werkzeug.urls import url_encode
 from importlib import import_module
 
+from urllib.parse import urljoin
 from fame.core import fame_init
 from fame.core.user import User
 from fame.common.config import fame_config
@@ -150,7 +151,7 @@ def modify_query(key, value):
 
 @app.route('/')
 def root():
-    return redirect('/analyses')
+    return redirect(urljoin(fame_config.fame_url, '/analyses/'))
 
 
 FilesView.register(app)


### PR DESCRIPTION
This PR force flask's `redirect()` function to respect the url/scheme defined in `fame.conf`
