### PR TITLE
renew auth_token on login, invalidate it on logout

### DIFF
--- a/web/auth/user_password/user_management.py
+++ b/web/auth/user_password/user_management.py
@@ -56,10 +56,8 @@ def authenticate(email, password):
     if user_if_enabled(user):
         if 'pwd_hash' in user:
             if check_password_hash(user['pwd_hash'], password):
-                if 'auth_token' not in user:
-                    user.update_value('auth_token', auth_token(user))
+                user.update_value('auth_token', auth_token(user))
                 user.update_value('last_activity', datetime.now().timestamp())
-
                 login_user(user)
                 return user
 

--- a/web/auth/user_password/views.py
+++ b/web/auth/user_password/views.py
@@ -10,7 +10,7 @@ from fame.common.config import fame_config
 from fame.common.email_utils import EmailServer
 from fame.core.user import User
 from web.views.helpers import prevent_csrf, get_or_404
-from web.auth.user_password.user_management import authenticate, change_password, password_reset_token, validate_password_reset_token
+from web.auth.user_password.user_management import authenticate, change_password, password_reset_token, validate_password_reset_token, auth_token
 
 auth = Blueprint('auth', __name__, template_folder='templates')
 
@@ -125,6 +125,8 @@ def login():
 
 @auth.route('/logout')
 def logout():
+    if current_user.is_authenticated:
+        current_user.update_value('auth_token', auth_token(current_user))
     logout_user()
     return redirect(urljoin(fame_config.fame_url, '/login'))
 


### PR DESCRIPTION
This aims to restrain possibilities for session hijacking via cookie theft. 

This PR has a side effect : it prevents having an user being logged in on FAME from multiple browser/multiple device at the same time (multitab is still supported) ... I don't think that's a big issue though