### PR TITLE
bump requests to 2.25.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ sphinxcontrib-httpdomain~=1.7.0
 celery~=4.4.7
 pymongo~=3.11.0
 python-magic~=0.4.18
-requests~=2.24.0
+requests~=2.25.1
 Flask-Login~=0.5.0
 zxcvbn==4.4.28
 GitPython~=3.1.7


### PR DESCRIPTION
Newer versions of hatching-triage require request >= 2.25.1