### PR TITLE
Report error when a FAME module can't be loaded

### DIFF
--- a/fame/core/repository.py
+++ b/fame/core/repository.py
@@ -62,7 +62,8 @@ class Repository(MongoDict):
                 Repo.clone_from(self['address'], self.path())
 
             dispatcher.update_modules(self)
-            self.update_value('status', 'active')
+            if self['status'] == 'cloning':
+                self.update_value('status', 'active')
         except Exception as e:
             self['status'] = 'error'
             self['error_msg'] = 'Could not clone repository, probably due to authentication issues.\n{}'.format(e)
@@ -95,7 +96,8 @@ class Repository(MongoDict):
                         os.remove(f)
 
             dispatcher.update_modules(self)
-            self.update_value('status', 'active')
+            if self['status'] == 'updating':
+                self.update_value('status', 'active')
         except Exception as e:
             self['status'] = 'error'
             self['error_msg'] = 'Could not update repository.\n{}'.format(e)


### PR DESCRIPTION
When a module can't be loaded, it get silently ignored, without any warning or error message..which makes debugging quite difficult.
This PR display an error both in the updater logs & on the FAME web interface, in case of failed module import

Related to #114 