### PR TITLE
bump requests to the latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ sphinxcontrib-httpdomain~=1.7.0
 celery~=5.2.7
 pymongo~=3.11.0
 python-magic~=0.4.18
-requests~=2.25.1
+requests~=2.28.1
 Flask-Login~=0.5.0
 zxcvbn==4.4.28
 GitPython~=3.1.7


### PR DESCRIPTION
This prevents warnings like `urllib3 (1.25.11) or chardet (5.0.0) doesn't match a supported version!`, which are currently being displayed when running the web server & the worker on the same machine.