### PR TITLE
docker : Configure git username/email, make DinD images persistent, allow git key to be defined at startup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,7 +51,8 @@ RUN chown -R fame:fame /opt/fame
 
 USER fame
 
-RUN cd /opt/fame && mkdir -p env storage temp && pip3 install virtualenv
+RUN cd /opt/fame && mkdir -p env storage temp && pip3 install virtualenv \
+    && git config --global user.name fame && git config --global user.email git@fame
 
 CMD ["/opt/fame/docker/docker-entrypoint.sh", "web"]
 EXPOSE 4200

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,9 +10,8 @@ volumes:
   storage:
   avatars:
   temp:
-  env_web:
-  env_worker:
-  env_updater:
+  env:
+  docker:
 
 services:
   fame_web:
@@ -34,7 +33,7 @@ services:
       - fame_db
     volumes:
       - modules:/opt/fame/fame/modules/
-      - env_web:/opt/fame/env/
+      - env:/opt/fame/env/
       - storage:/opt/fame/fame/storage/
       - temp:/opt/fame/fame/temp/
       - avatars:/opt/fame/web/static/img/avatars/
@@ -50,7 +49,8 @@ services:
     container_name: fame_worker
     volumes:
       - modules_worker:/opt/fame/fame/modules/
-      - env_worker:/opt/fame/env/
+      - env:/opt/fame/env/
+      - docker:/var/lib/docker
     entrypoint: /bin/sh
     command: -c "wait-for -t 0 fame_web:4200 && /opt/fame/docker/docker-entrypoint.sh worker"
     networks:
@@ -80,7 +80,7 @@ services:
       - fame_web
     volumes:
       - modules:/opt/fame/fame/modules/
-      - env_updater:/opt/fame/env/
+      - env:/opt/fame/env/
 
   fame_db:
     image: mongo:latest

--- a/docker/fame.env.template
+++ b/docker/fame.env.template
@@ -6,3 +6,5 @@ MONGODB_USERNAME=user
 MONGODB_PASSWORD=pass
 
 FAME_URL=http://fame_web:4200
+
+# FAME_GIT_SSH_KEY=  #Enter here the result of: awk '{printf "%s\\n", $0}' myprivatekey.key


### PR DESCRIPTION
This PR offer multiple improvments when running FAME with docker:

- define user.name/user.email. This fix an error (``fatal: unable to auto-detect email address``) when updating repositories  from the web interface
- move DinD images to a dedicated volume (this helps to reduce docker startup time)
- allow the git SSH key to be persistent across startups (using `fame.env`)