### PR TITLE
MongoDB: use `MongoClient()` instead of `authenticate()`

### DIFF
--- a/celeryconfig.py
+++ b/celeryconfig.py
@@ -1,3 +1,4 @@
+from urllib.parse import quote_plus
 from kombu.serialization import register
 from bson.json_util import dumps, loads
 from celery import signals
@@ -9,7 +10,7 @@ register('json_util', dumps, loads, content_type='application/json', content_enc
 
 MONGO = 'mongodb://{}:{}/{}'.format(fame_config.mongo_host, fame_config.mongo_port, fame_config.mongo_db)
 if fame_config.mongo_user and fame_config.mongo_password:
-    MONGO = 'mongodb://{}:{}@{}:{}/{}'.format(fame_config.mongo_user, fame_config.mongo_password, fame_config.mongo_host, fame_config.mongo_port, fame_config.mongo_db)
+    MONGO = 'mongodb://{}:{}@{}:{}/{}'.format(fame_config.mongo_user, quote_plus(fame_config.mongo_password), fame_config.mongo_host, fame_config.mongo_port, fame_config.mongo_db)
 
 broker_url = MONGO
 accept_content = ['json_util']

--- a/fame/core/store.py
+++ b/fame/core/store.py
@@ -1,5 +1,3 @@
-from urllib.parse import quote_plus
-
 from pymongo import TEXT, MongoClient
 
 from fame.common.config import fame_config
@@ -11,7 +9,17 @@ class Store:
 
     def init(self):
         # Connection
-        self._con = MongoClient(fame_config.mongo_host, int(fame_config.mongo_port), serverSelectionTimeoutMS=10000)
+        if fame_config.mongo_user and fame_config.mongo_password:
+            self._con = MongoClient(host=fame_config.mongo_host,
+                port=int(fame_config.mongo_port),
+                serverSelectionTimeoutMS=10000,
+                username=fame_config.mongo_user,
+                password=fame_config.mongo_password,
+                authSource=fame_config.mongo_db)
+        else:
+            self._con = MongoClient(host=fame_config.mongo_host,
+                port=int(fame_config.mongo_port),
+                serverSelectionTimeoutMS=10000)
         self.db = self._con[fame_config.mongo_db]
 
         # Collections
@@ -31,12 +39,6 @@ class Store:
 
     def connect(self):
         self.init()
-
-        # Authenticate
-        if fame_config.mongo_user and fame_config.mongo_password:
-            self.db.authenticate(
-                fame_config.mongo_user, quote_plus(fame_config.mongo_password), mechanism="SCRAM-SHA-1"
-            )
 
         # Create indexes
         self.files.create_index("md5")

--- a/utils/install.py
+++ b/utils/install.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import errno
-from urllib.parse import quote_plus
 from urllib.parse import urljoin
 from subprocess import run, PIPE
 
@@ -71,7 +70,13 @@ def define_mongo_connection(context):
 
     if not test_mongodb_connection(db):
         try:
-            db.authenticate(context['mongo_user'], quote_plus(context['mongo_password']))
+            mongo = MongoClient(host=context['mongo_host'],
+                port=context['mongo_port'],
+                serverSelectionTimeoutMS=10000,
+                username=context['mongo_user'],
+                password=context['mongo_password'],
+                authSource="fame")
+            db = mongo[context['mongo_db']]
         except:
             error("Could not connect to MongoDB (invalid credentials).")
 

--- a/utils/troubleshoot.py
+++ b/utils/troubleshoot.py
@@ -50,7 +50,13 @@ def mongodb():
         db = connection[fame_config.mongo_db]
 
         if fame_config.mongo_user and fame_config.mongo_password:
-            db.authenticate(fame_config.mongo_user, quote_plus(fame_config.mongo_password), mechanism='SCRAM-SHA-1')
+            mongo = MongoClient(host=fame_config.mongo_host,
+                port=int(fame_config.mongo_port),
+                serverSelectionTimeoutMS=10000,
+                username=fame_config.mongo_user,
+                password=fame_config.mongo_password,
+                authSource="fame")
+            db = mongo[fame_config.mongo_db]
 
         print(("Version: {}".format(connection.server_info()['version'])))
         print(("Authorization check: {}\n".format(test_mongodb_connection(db))))


### PR DESCRIPTION
`authenticate()` is deprecated and [is removed](https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html?#database-authenticate-and-database-logout-are-removed) in pyMongo 4.x