### PR TITLE
Correct add_extracted file to save a file if only hash previously exist.

### DIFF
--- a/fame/core/analysis.py
+++ b/fame/core/analysis.py
@@ -110,7 +110,7 @@ class Analysis(MongoDict):
         filename = os.path.basename(filepath)
         f = File(filename=filename, stream=fd, create=False)
 
-        if not f.existing:
+        if not f.existing or f['type'] == 'hash':
             if fame_config.remote:
                 response = send_file_to_remote(filepath, '/files/')
                 f = File(response.json()['file'])


### PR DESCRIPTION
Correct add_extracted file to save a file to Fame if the hash is already present but only hash (e.g. previous hash analysis with virustotal_download for unknown hash).