### PR TITLE
Fix redirection after login

### DIFF
--- a/web/auth/ad/templates/login.html
+++ b/web/auth/ad/templates/login.html
@@ -3,8 +3,7 @@
 {% block title %}Login{% endblock %}
 
 {% block body %}
-    <form method="post" action="{{url_for('auth.login')}}">
-
+    <form method="post" action="{{url_for('auth.login', next=request.args.get('next'))}}">
         <div class="card">
             <div class="content">
                 <div class="form-group">

--- a/web/auth/user_password/templates/login.html
+++ b/web/auth/user_password/templates/login.html
@@ -3,7 +3,7 @@
 {% block title %}Login{% endblock %}
 
 {% block body %}
-    <form method="post" action="{{url_for('auth.login')}}">
+    <form method="post" action="{{url_for('auth.login', next=request.args.get('next'))}}">
 
         <div class="card">
             <div class="content">


### PR DESCRIPTION
The `?next=`  parameter is currently not used by the login HTML form. 
Because of this, logins are currently all redirecting to `/analyses/`.