### PR TITLE
always return JSON when answering an API call

### DIFF
--- a/web/views/negotiation.py
+++ b/web/views/negotiation.py
@@ -5,9 +5,10 @@ from bson.json_util import dumps
 
 
 def should_render_as_html():
-    best = request.accept_mimetypes.best_match(["text/html", "application/json"])
+    best_accept = request.accept_mimetypes.best_match(["text/html", "application/json"])
+    api_key = bool(request.headers.get('X-API-KEY'))
 
-    return best == "text/html"
+    return best_accept == "text/html" and not api_key
 
 
 def render_json(data):


### PR DESCRIPTION
This PR proposes to use the `X-API-KEY` header to detect API calls and return JSON accordingly 

Close https://github.com/certsocietegenerale/fame/issues/57