### PR TITLE
Ask users to confirm when submitting an analysis which looks wrong

### DIFF
--- a/utils/initial_data.py
+++ b/utils/initial_data.py
@@ -138,10 +138,40 @@ virustotal_public
         })
         extracted.save()
 
+def create_safe_domains():
+    safe_domains = Config.get(name='safe_domains')
+    if safe_domains is None:
+        safe_domains = Config({
+            'name': 'safe_domains',
+            'description': 'Define (sub)domains which are trusted and should not be analyzed',
+            'config': [
+                {
+                    'name': 'trusted_domains',
+                    'description': 'Safe (sub)domains which should not be analyzed. Users will still be able to force analysis but will be warned before doing so. Only enter domains you own or fully trust in this field\n',
+                    'type': 'text',
+                    'default': """*.mycompany.lan
+www.mycompany.com
+""",
+                    'value': None
+                },
+                {
+                    'name': 'untrusted_domains',
+                    'description': '(sub)domains which should be considered as untrusted despite being part of a trusted (sub)domain',
+                    'type': 'text',
+                    'default': """*.untrusted-subdomain.mycompany.lan
+untrusted-subdomain.www.mycompany.com
+""",
+                    'value': None
+                }
+            ]
+        })
+
+        safe_domains.save()
 
 def create_initial_data():
     create_types()
     create_internals()
+    create_safe_domains()
     create_comment_configuration()
     create_extracted_schedule()
 

--- a/web/static/js/fame.js
+++ b/web/static/js/fame.js
@@ -13,7 +13,7 @@ function enable_checkboxes() {
 function auto_update(url, time, selector) {
   setTimeout(function () {
     if (should_refresh) {
-      $.get(url).success(function (html) {
+      $.get(url).done(function (html) {
         if (should_refresh) {
           html = $(html);
           $(selector).each(function (i) {
@@ -43,7 +43,7 @@ function add_options() {
   $('select[data-addoptions]').each(function (index) {
     select = $(this);
     url = select.data('addoptions');
-    $.getJSON(url).success(add_options_to_select(select));
+    $.getJSON(url).done(add_options_to_select(select));
   });
 }
 
@@ -63,7 +63,7 @@ function enable_delete_links() {
     $.ajax({
       url: url,
       method: 'DELETE'
-    }).success(function (data) {
+    }).done(function (data) {
       parent.remove();
     });
 
@@ -171,7 +171,7 @@ function enable_ioc_submission() {
       type: 'POST',
       url: url,
       data: JSON.stringify(iocs),
-      success: callback,
+      done: callback,
       error: errorCallback,
       contentType: 'application/json',
     });
@@ -232,7 +232,7 @@ function enable_av_submission() {
     $.ajax({
       type: 'POST',
       url: url,
-      success: callback,
+      done: callback,
       error: errorCallback,
       contentType: 'application/json',
     });

--- a/web/static/js/verify-input.js
+++ b/web/static/js/verify-input.js
@@ -1,0 +1,45 @@
+
+$("form[id='submit']").on("submit", function(event) {
+  if($('.nav-pills a[href="#url"]').attr('aria-expanded')) {
+    let parser = document.createElement('a');
+
+    parser.href = $("input[name='url']").val();
+    if ($("input[name='url']").val().indexOf('://') == -1) {
+      parser.href = 'http://' + $("input[name='url']").val(); // force the URL to be considered as absolute
+    }
+
+    if((parser.protocol != "https:" && parser.protocol != "http:") || parser.hostname.indexOf('.') == -1) {
+      msg = "This does not look like a valid URL. Are you sure you want to analyze it?\nYou can force the analysis by clicking on \"OK\"."
+      if (!confirm(msg)) {
+        event.preventDefault();
+      }
+    } else {
+      event.preventDefault();
+      $.ajax({
+        url: "/analyses/is_safe_url",
+        method: 'POST',
+        context: $(this),
+        data: { url: $("input[name='url']").val()},
+      }).done(function (data) {
+          msg = "This URL seems to point to a safe domain. Are you sure you want to analyze it?\nYou can force the analysis by clicking on \"OK\"."
+          if(!data.is_safe || confirm(msg)) {
+            this.off('submit');
+            this.submit();
+          }
+      });
+    }
+  } else if ($('.nav-pills a[href="#hash"]').attr('aria-expanded')) {
+    let hash = $("input[name='hash']").val();
+    if (!/^[a-fA-F0-9]{32}$/.test(hash) // MD5
+     && !/^[a-fA-F0-9]{40}$/.test(hash) // SHA1
+     && !/^[a-fA-F0-9]{56}$/.test(hash) // SHA224
+     && !/^[a-fA-F0-9]{64}$/.test(hash) // SHA256
+     && !/^[a-fA-F0-9]{96}$/.test(hash) // SHA384
+     && !/^[a-fA-F0-9]{128}$/.test(hash)) { // SHA512
+      msg = "This does not look like a valid hash format. Are you sure you want to analyze it?\nYou can force the analysis by clicking on \"OK\"."
+      if (!confirm(msg)) {
+        event.preventDefault();
+      }
+     }
+  }
+});

--- a/web/templates/analyses/new.html
+++ b/web/templates/analyses/new.html
@@ -81,5 +81,6 @@
 </script>
 
 <script src="{{ url_for('static', filename='js/modules-autocomplete.js') }}"></script>
+<script src="{{ url_for('static', filename='js/verify-input.js') }}"></script>
 {% endblock %}
 


### PR DESCRIPTION
This PR adds a confirmation popup from the end users when submitting an analysis which looks wrong

The popup is only triggered when:
- The URL looks invalid (unusual scheme like `phone://`, no TLD, etc) or belongs to a known internal/fully trusted domain (configurable in the settings)
- The hash format looks invalid

This does not affect API submission, and the message is non-binding (end-users can still force the analysis)