### PR TITLE
Bump requests to 2.31.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ sphinxcontrib-httpdomain~=1.7.0
 celery~=5.2.7
 pymongo~=3.11.0
 python-magic~=0.4.18
-requests~=2.28.1
+requests>=2.31.0
 Flask-Login~=0.6.2
 zxcvbn==4.4.28
 GitPython~=3.1.7


### PR DESCRIPTION
This fixes GHSA-j8r2-6x86-q33q