### PR TITLE
Move docker build to Debian bookworm

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -3,7 +3,7 @@ import sys
 import inspect
 import importlib
 import traceback
-import collections
+import collections.abc
 from uuid import uuid4
 from tempfile import mkstemp
 from shutil import copyfileobj
@@ -21,7 +21,7 @@ sys.path.append(AGENT_ROOT)
 
 
 def is_iterable(element):
-    return isinstance(element, collections.Iterable) and not isinstance(element, str)
+    return isinstance(element, collections.abc.Iterable) and not isinstance(element, str)
 
 
 def iterify(element):

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN apt update && \
   zlib1g-dev \
   libmagic-dev \
   apt-transport-https \
-  netcat \
+  netcat-traditional \
   ca-certificates \
   curl \
   gnupg2 \
@@ -25,28 +25,19 @@ RUN apt update && \
   sudo \
   default-jdk \
   unzip \
-  software-properties-common
+  software-properties-common \
+  protobuf-compiler
 
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
-    add-apt-repository \
-    "deb [arch=amd64] https://download.docker.com/linux/debian \
-    $(lsb_release -cs) \
-    stable"
-
-RUN curl -o /bin/wait-for https://raw.githubusercontent.com/eficode/wait-for/master/wait-for && \
-    chmod +x /bin/wait-for
-
-# some FAME module require protobuf-compiler >= 3.19.0
-RUN curl -fsSL -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v21.6/protoc-21.6-linux-x86_64.zip && \
-    unzip /tmp/protoc.zip -d /tmp/protoc && \
-    mv /tmp/protoc/bin/* /usr/local/bin && mv /tmp/protoc/include/* /usr/local/include && \
-    rm -rf /tmp/protoc /tmp/protoc.zip
-
-RUN apt-get update && apt-get install -y \
+    echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" >> /etc/apt/sources.list.d/docker.list && \
+    apt update && apt install -y \
     docker-ce \
     docker-ce-cli \
     containerd.io
 
+
+RUN curl -o /bin/wait-for https://raw.githubusercontent.com/eficode/wait-for/master/wait-for && \
+    chmod +x /bin/wait-for
 
 RUN groupadd -r fame && \
     useradd -M -r -d /opt/fame -g fame -G docker fame && \
@@ -60,7 +51,7 @@ RUN chown -R fame:fame /opt/fame
 
 USER fame
 
-RUN cd /opt/fame && mkdir -p env storage temp && pip3 install virtualenv \
+RUN cd /opt/fame && mkdir -p env storage temp && pip3 install virtualenv --break-system-packages \
     && git config --global user.name fame && git config --global user.email git@fame
 
 CMD ["/opt/fame/docker/docker-entrypoint.sh", "web"]

--- a/fame/common/mongo_dict.py
+++ b/fame/common/mongo_dict.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 
 from fame.common.utils import iterify
 from fame.core.store import store
@@ -50,7 +50,7 @@ class MongoDict(dict):
     def update_value(self, names, value):
         mongo_field = self._mongo_field(names)
 
-        if isinstance(names, collections.Iterable) and not isinstance(names, str):
+        if isinstance(names, collections.abc.Iterable) and not isinstance(names, str):
             last = names.pop()
             self._local_field(names)[last] = value
         else:
@@ -82,7 +82,7 @@ class MongoDict(dict):
         return local_field
 
     def _mongo_field(self, names):
-        if isinstance(names, collections.Iterable) and not isinstance(names, str):
+        if isinstance(names, collections.abc.Iterable) and not isinstance(names, str):
             return '.'.join(names)
         else:
             return names

--- a/fame/common/utils.py
+++ b/fame/common/utils.py
@@ -1,6 +1,6 @@
 import os
 import requests
-import collections
+import collections.abc
 from time import sleep
 from uuid import uuid4
 from urllib.parse import urljoin
@@ -12,7 +12,7 @@ from fame.common.config import fame_config
 
 
 def is_iterable(element):
-    return isinstance(element, collections.Iterable) and not isinstance(element, str)
+    return isinstance(element, collections.abc.Iterable) and not isinstance(element, str)
 
 
 def iterify(element):


### PR DESCRIPTION
Debian bookwork got released 3 days ago. This PR makes FAME compatible with the new version

2 modules are in error with this version bump: kvm & stringsifter 