### PR TITLE
UPD search.py to show avatar picture in Object part of search page

### DIFF
--- a/web/views/search.py
+++ b/web/views/search.py
@@ -14,16 +14,17 @@ class SearchView(FlaskView, UIView):
 
         files = []
         for file in current_user.files.find({'$text': {'$search': query}}):
+            if 'reviewed' in file and file['reviewed']:
+                reviewer = store.users.find_one({'_id': file['reviewed']})
+                file['reviewed'] = clean_users(reviewer)
+
             files.append(file)
 
         analyses = []
         for analysis in current_user.analyses.find({'$text': {'$search': query}}):
             file = current_user.files.find_one({'_id': analysis['file']})
             analysis['file'] = clean_files(file)
-            analyses.append(analysis)
 
-        results = {'files': clean_files(files), 'analyses': clean_analyses(analyses)}
-        for analysis in analyses:
             if 'analyst' in analysis:
                 analyst = store.users.find_one({'_id': analysis['analyst']})
                 analysis['analyst'] = clean_users(analyst)
@@ -32,9 +33,8 @@ class SearchView(FlaskView, UIView):
                 reviewer = store.users.find_one({'_id': analysis['reviewed']})
                 analysis['reviewed'] = clean_users(reviewer)
 
-        for file in files:
-            if 'reviewed' in file and file['reviewed']:
-                reviewer = store.users.find_one({'_id': file['reviewed']})
-                file['reviewed'] = clean_users(reviewer)
+            analyses.append(analysis)
+
+        results = {'files': clean_files(files), 'analyses': clean_analyses(analyses)}
 
         return render(results, 'search.html')

--- a/web/views/search.py
+++ b/web/views/search.py
@@ -32,4 +32,9 @@ class SearchView(FlaskView, UIView):
                 reviewer = store.users.find_one({'_id': analysis['reviewed']})
                 analysis['reviewed'] = clean_users(reviewer)
 
+        for file in files:
+            if 'reviewed' in file and file['reviewed']:
+                reviewer = store.users.find_one({'_id': file['reviewed']})
+                file['reviewed'] = clean_users(reviewer)
+
         return render(results, 'search.html')


### PR DESCRIPTION
I noticed that the avatar id was missing in the file part of the search page resulting in default icon to be placed on reviewed objects. 
This PR should solve this issue by adapting what has been done on analyses to files