### PR TITLE
Improve sanitization of submitted and extracted file names

### DIFF
--- a/fame/common/utils.py
+++ b/fame/common/utils.py
@@ -64,14 +64,19 @@ def ordered_list_value(list_of_values):
     return result
 
 
-def send_file_to_remote(file, url):
+def send_file_to_remote(file, url, filename=''):
     if isinstance(file, str):
         file = open(file, 'rb')
+
+    if filename:
+        file = (filename, file)
 
     url = urljoin(fame_config.remote, url)
     response = requests.post(url, files={'file': file}, headers={'X-API-KEY': fame_config.api_key})
     response.raise_for_status()
 
+    if filename:
+        file = file[1]
     file.close()
 
     return response
@@ -115,3 +120,10 @@ def with_timeout(func, timeout, step):
         sleep(step)
 
     return None
+
+def sanitize_filename(filename, alternative_name):
+    sanitized_filename = secure_filename(filename)
+    if not sanitized_filename or len(sanitized_filename) > 200:
+        sanitized_filename = alternative_name
+    sanitized_filename = sanitized_filename.replace('-', '_')
+    return sanitized_filename

--- a/fame/core/analysis.py
+++ b/fame/core/analysis.py
@@ -106,19 +106,20 @@ class Analysis(MongoDict):
         if self.magic_enabled():
             self.queue_modules(dispatcher.triggered_by("_generated_file(%s)" % file_type))
 
-    def add_extracted_file(self, filepath, automatic_analysis=True):
+    def add_extracted_file(self, filepath, filename, automatic_analysis=True):
         self.log('debug', "Adding extracted file '{}'".format(filepath))
 
+        if not filename:
+            filename = os.path.basename(filepath)
         fd = open(filepath, 'rb')
-        filename = os.path.basename(filepath)
         f = File(filename=filename, stream=fd, create=False)
 
         if not f.existing or f['type'] == 'hash':
             if fame_config.remote:
-                response = send_file_to_remote(filepath, '/files/')
+                response = send_file_to_remote(filepath, '/files/', filename)
                 f = File(bson_loads(dumps(response.json()['file'])))
             else:
-                f = File(filename=os.path.basename(filepath), stream=fd)
+                f = File(filename=filename, stream=fd)
 
             # Automatically analyze extracted file if magic is enabled and module did not disable it
             if self.magic_enabled() and automatic_analysis:

--- a/fame/core/module.py
+++ b/fame/core/module.py
@@ -350,12 +350,13 @@ class ProcessingModule(Module):
             skip (optional): True if the analysis review should be skipped, False otherwise."""
         self._analysis.skip_review(skip)
 
-    def add_extracted_file(self, location, automatic_analysis=True):
+    def add_extracted_file(self, location, filename='', automatic_analysis=True):
         """Create a new file that deserves its own analysis.
 
         Args:
-            location (string): full path."""
-        self._analysis.add_extracted_file(location, automatic_analysis)
+            location (string): full path.
+            filename (string): file name."""
+        self._analysis.add_extracted_file(location, filename, automatic_analysis)
 
     def add_support_file(self, name, location):
         """Add a support file to this analysis. A support file is a file that

--- a/web/views/files.py
+++ b/web/views/files.py
@@ -162,7 +162,7 @@ class FilesView(FlaskView, UIView):
     @requires_permission("worker")
     def post(self):
         file = request.files["file"]
-        f = File(filename=secure_filename(file.filename), stream=file.stream)
+        f = File(filename=file.filename, stream=file.stream)
 
         return render_json({"file": f})
 


### PR DESCRIPTION
Submitted and extracted file names are not consistent depending if FAME is used with a remote worker or a local one. Also, in general file names are poorly sanitized, which can lead to issues like `filename too long` in some specific situations.

This PR aims to separate the name of the file on disk from the actual file name, and to improve sanitization of the file name on disk.