### PR TITLE
Delete old analyses/files, as well as old disabled users automatically

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -145,7 +145,7 @@ You are first presented with a list of existing users:
 
 On a fresh install, you will have only your administrator account created, an optionally an account named "FAME Worker" ``(1)``. This account is needed when using remote workers, so you should not delete or disable it.
 
-From the list of users, you can disable ``(2)`` or enable ``(3)`` a user. A disabled user cannot log in to your FAME instance. User accounts cannot be deleted because they are linked to previous analyses.
+From the list of users, you can disable ``(2)`` or enable ``(3)`` a user. A disabled user cannot log in to your FAME instance. Disabled user accounts are automatically deleted after 30 days, based on their last activity.
 
 Clicking on the name of a user will let you :ref:`admin-user-edit`.
 

--- a/fame/common/cleaner.py
+++ b/fame/common/cleaner.py
@@ -18,47 +18,43 @@ def ignore_file(f, config):
 
 
 def get_old_analyses():
-    config = Config.get(name="remove_old_data").get_values()
-    old_analyses_dict = {}
-
-    if not config or not config.time or config.time <= 0:
-        return set(), set()
-
-    since = datetime.now() - timedelta(days=config.time)
+    config = Config.get(name="cleaner").get_values()
 
     old_analyses = set()
     old_files = set()
 
-    for analysis in Analysis.find({"date": {"$lte": since}}):
-        if ignore_file(analysis._file, config):
-            continue
-        old_analyses.add(analysis)
+    if config and config.time and config.time > 0:
+        since = datetime.now() - timedelta(days=config.time)
 
-        # if all the file's analyses are older than the threshold: remove the associated file
-        if all(
-            [Analysis.get(_id=a)["date"] < since for a in analysis._file["analysis"]]
-        ):
-            old_files.add(analysis._file)
+        for analysis in Analysis.find({"date": {"$lte": since}}):
+            if ignore_file(analysis._file, config):
+                continue
+            old_analyses.add(analysis)
 
-    for f in File.find({"analysis": []}):
-        if ignore_file(f, config):
-            continue
+            # if all the file's analyses are older than the threshold: remove the associated file
+            if all(
+                [
+                    Analysis.get(_id=a)["date"] < since
+                    for a in analysis._file["analysis"]
+                ]
+            ):
+                old_files.add(analysis._file)
 
-        # if the file has parent analyses: keep extracted files if any analysis doesn't meet the threshold
-        if any([Analysis.get(_id=a)["date"] > since for a in f["parent_analyses"]]):
-            continue
+        for f in File.find({"analysis": []}):
+            if ignore_file(f, config):
+                continue
 
-        old_files.add(f)
+            # if the file has parent analyses: keep extracted files if any analysis doesn't meet the threshold
+            if any([Analysis.get(_id=a)["date"] > since for a in f["parent_analyses"]]):
+                continue
+
+            old_files.add(f)
 
     return old_analyses, old_files
 
 
 def get_old_disabled_users():
-    config = Config.get(name="remove_old_data").get_values()
-    if not config or not config.time or config.time <= 0:
-        return set()
-
-    since = datetime.now() - timedelta(days=config.time)
+    since = datetime.now() - timedelta(days=30)
 
     old_users = set()
 

--- a/fame/common/cleaner.py
+++ b/fame/common/cleaner.py
@@ -1,0 +1,76 @@
+from fame.core.config import Config
+from fame.core.file import File
+from fame.core.analysis import Analysis
+from fame.core.user import User
+from fame.core.module import ModuleInfo
+
+from datetime import datetime, timedelta
+
+
+def ignore_file(f, config):
+    if f["type"] in config.types_to_exclude:
+        return True
+    if f["comments"] and config.keep_when_comment:
+        return True
+    if f["probable_names"] and config.keep_when_probable_name:
+        return True
+    return False
+
+
+def get_old_analyses():
+    config = Config.get(name="remove_old_data").get_values()
+    old_analyses_dict = {}
+
+    if not config or not config.time or config.time <= 0:
+        return set(), set()
+
+    since = datetime.now() - timedelta(days=config.time)
+
+    old_analyses = set()
+    old_files = set()
+
+    for analysis in Analysis.find({"date": {"$lte": since}}):
+        if ignore_file(analysis._file, config):
+            continue
+        old_analyses.add(analysis)
+
+        # if all the file's analyses are older than the threshold: remove the associated file
+        if all(
+            [Analysis.get(_id=a)["date"] < since for a in analysis._file["analysis"]]
+        ):
+            old_files.add(analysis._file)
+
+    for f in File.find({"analysis": []}):
+        if ignore_file(f, config):
+            continue
+
+        # if the file has parent analyses: keep extracted files if any analysis doesn't meet the threshold
+        if any([Analysis.get(_id=a)["date"] > since for a in f["parent_analyses"]]):
+            continue
+
+        old_files.add(f)
+
+    return old_analyses, old_files
+
+
+def get_old_disabled_users():
+    config = Config.get(name="remove_old_data").get_values()
+    if not config or not config.time or config.time <= 0:
+        return set()
+
+    since = datetime.now() - timedelta(days=config.time)
+
+    old_users = set()
+
+    for user in User.find(
+        {
+            "$or": [
+                {"last_activity": {"$lte": since.timestamp()}},
+                {"last_activity": {"$exists": False}},
+            ]
+        },
+        enabled=False,
+    ):
+        old_users.add(user)
+
+    return old_users

--- a/fame/common/mongo_dict.py
+++ b/fame/common/mongo_dict.py
@@ -13,12 +13,18 @@ class MongoDict(dict):
         dict.__init__(self, values)
         self.collection = store.db[self.collection_name]
 
+    def __hash__(self):
+        return hash(self['_id'])
+
     @classmethod
     def get_collection(klass):
         return store.db[klass.collection_name]
 
     @classmethod
     def find(klass, *args, **kwargs):
+        if len(args) == 1 and isinstance(args[0], dict):
+            kwargs |= args[0]
+
         objs = klass.get_collection().find(kwargs)
 
         for obj in objs:
@@ -26,6 +32,9 @@ class MongoDict(dict):
 
     @classmethod
     def get(klass, *args, **kwargs):
+        if len(args) == 1 and isinstance(args[0], dict):
+            kwargs |= args[0]
+
         obj = klass.get_collection().find_one(kwargs)
 
         if obj:

--- a/fame/common/utils.py
+++ b/fame/common/utils.py
@@ -127,3 +127,24 @@ def sanitize_filename(filename, alternative_name):
         sanitized_filename = alternative_name
     sanitized_filename = sanitized_filename.replace('-', '_')
     return sanitized_filename
+
+def delete_from_disk(top):
+    fame_path = os.path.normpath(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
+    )
+    if not fame_path in top:
+        print(
+            "WARNING: refusing to delete '{}' because it is outside of '{}'.".format(
+                top, fame_path
+            )
+        )
+        return
+    for root, dirs, files in os.walk(top, topdown=False):
+        for name in files:
+            os.remove(os.path.join(root, name))
+        for name in dirs:
+            os.rmdir(os.path.join(root, name))
+    if os.path.isdir(top):
+        os.rmdir(top)
+    elif os.path.isfile(top):
+        os.remove(top)

--- a/fame/core/analysis.py
+++ b/fame/core/analysis.py
@@ -9,12 +9,13 @@ from bson.json_util import loads as bson_loads
 from json import dumps
 
 from fame.common.config import fame_config
-from fame.common.utils import iterify, u, send_file_to_remote
+from fame.common.utils import iterify, u, send_file_to_remote, delete_from_disk
 from fame.common.mongo_dict import MongoDict
 from fame.core.store import store
 from fame.core.celeryctl import celery
 from fame.core.module_dispatcher import dispatcher, DispatchingException
 from fame.core.config import Config
+from fame.core.module import ModuleInfo
 
 
 # Celery task to retrieve analysis object and run specific module on it
@@ -515,6 +516,25 @@ class Analysis(MongoDict):
         self.log("error", "{}: {}".format(module, message))
         self.append_to('canceled_modules', module)
 
+    def delete(self, force=False):
+        # Delete support files
+        for module in ModuleInfo.find():
+            support_files = os.path.join(fame_config.storage_path, "support_files", module['name'], str(self['_id']))
+            delete_from_disk(support_files)
+
+        config = Config.get(name="remove_old_data").get_values()
+        if config.preserve_db and not force:
+            return
+
+        for file_to_update in File.find({"analysis": self['_id']}):
+            if file_to_update:
+                file_to_update.remove_from('analysis', self['_id'])
+
+        for file_to_update in File.find({"parent_analyses": self['_id']}):
+            if file_to_update:
+                file_to_update.remove_from('parent_analyses', self['_id'])
+
+        super().delete()
 
 # For cyclic imports
 from fame.core.file import File

--- a/fame/core/analysis.py
+++ b/fame/core/analysis.py
@@ -516,14 +516,13 @@ class Analysis(MongoDict):
         self.log("error", "{}: {}".format(module, message))
         self.append_to('canceled_modules', module)
 
-    def delete(self, force=False):
+    def delete(self, preserve_db=False):
         # Delete support files
         for module in ModuleInfo.find():
             support_files = os.path.join(fame_config.storage_path, "support_files", module['name'], str(self['_id']))
             delete_from_disk(support_files)
 
-        config = Config.get(name="remove_old_data").get_values()
-        if config.preserve_db and not force:
+        if preserve_db:
             return
 
         for file_to_update in File.find({"analysis": self['_id']}):

--- a/fame/core/file.py
+++ b/fame/core/file.py
@@ -6,7 +6,7 @@ import datetime
 
 from fame.core.store import store
 from fame.common.config import ConfigObject, fame_config
-from fame.common.utils import sanitize_filename
+from fame.common.utils import sanitize_filename, delete_from_disk
 from fame.common.mongo_dict import MongoDict
 from fame.core.module_dispatcher import dispatcher
 from fame.core.config import Config
@@ -332,6 +332,24 @@ class File(MongoDict):
                 else:
                     stream.seek(0, 0)
                     break
+
+    def delete(self, force=False):
+        delete_from_disk(os.path.join(fame_config.storage_path, self['sha256']))
+
+        config = Config.get(name="remove_old_data").get_values()
+        if config.preserve_db and not force:
+            return
+
+        for objectid in self['analysis']:
+            analysis = Analysis.get(_id=objectid)
+            if analysis:
+                analysis.delete(force)
+
+        for analysis_to_update in Analysis.find({"extracted_files": self['_id']}):
+            if analysis_to_update:
+                analysis_to_update.remove_from('extracted_files', self['_id'])
+
+        super().delete()
 
 # For cyclic imports
 from fame.core.analysis import Analysis

--- a/fame/core/file.py
+++ b/fame/core/file.py
@@ -333,17 +333,16 @@ class File(MongoDict):
                     stream.seek(0, 0)
                     break
 
-    def delete(self, force=False):
+    def delete(self, preserve_db=False):
         delete_from_disk(os.path.join(fame_config.storage_path, self['sha256']))
-
-        config = Config.get(name="remove_old_data").get_values()
-        if config.preserve_db and not force:
-            return
 
         for objectid in self['analysis']:
             analysis = Analysis.get(_id=objectid)
             if analysis:
-                analysis.delete(force)
+                analysis.delete(preserve_db)
+
+        if preserve_db:
+            return
 
         for analysis_to_update in Analysis.find({"extracted_files": self['_id']}):
             if analysis_to_update:

--- a/fame/core/module_dispatcher.py
+++ b/fame/core/module_dispatcher.py
@@ -46,7 +46,7 @@ class ModuleDispatcher(object):
             ('add_probable_name', "Allows user to set an object's probable name"),
             ('see_logs', 'Allows user to access the log section of anlyses. This could reveal information on the underlying system.'),
             ('review', 'Allows user to review analyses. This is reserved to users analyzing submissions.'),
-            ('delete', 'Allows user to delete files and associated analyses.'),
+            ('delete', 'Allows user to anonymize (soft-delete) files and associated analyses.'),
         ])
 
         self.load_all_modules()

--- a/fame/core/module_dispatcher.py
+++ b/fame/core/module_dispatcher.py
@@ -45,7 +45,8 @@ class ModuleDispatcher(object):
             ('submit_iocs', 'Allows user to send observables to Threat Intelligence modules.'),
             ('add_probable_name', "Allows user to set an object's probable name"),
             ('see_logs', 'Allows user to access the log section of anlyses. This could reveal information on the underlying system.'),
-            ('review', 'Allows user to review analyses. This is reserved to users analyzing submissions.')
+            ('review', 'Allows user to review analyses. This is reserved to users analyzing submissions.'),
+            ('delete', 'Allows user to delete files and associated analyses.'),
         ])
 
         self.load_all_modules()

--- a/fame/core/user.py
+++ b/fame/core/user.py
@@ -3,7 +3,6 @@ import requests
 from base64 import b64encode
 
 from fame.core.store import store
-from fame.core.config import Config
 from fame.common.utils import delete_from_disk
 from fame.common.constants import AVATARS_ROOT
 from fame.common.mongo_dict import MongoDict
@@ -69,9 +68,7 @@ class User(MongoDict):
 
     def delete(self):
         delete_from_disk(os.path.join(AVATARS_ROOT, "{}.png".format(self['_id'])))
-        config = Config.get(name="remove_old_data").get_values()
-        if not config.preserve_db:
-            super().delete()
+        super().delete()
 
     @staticmethod
     def generate_api_key():

--- a/fame/core/user.py
+++ b/fame/core/user.py
@@ -3,6 +3,8 @@ import requests
 from base64 import b64encode
 
 from fame.core.store import store
+from fame.core.config import Config
+from fame.common.utils import delete_from_disk
 from fame.common.constants import AVATARS_ROOT
 from fame.common.mongo_dict import MongoDict
 
@@ -64,6 +66,12 @@ class User(MongoDict):
                 f.write(response.content)
         except:
             print(("Could not generate avatar for {}".format(self['email'])))
+
+    def delete(self):
+        delete_from_disk(os.path.join(AVATARS_ROOT, "{}.png".format(self['_id'])))
+        config = Config.get(name="remove_old_data").get_values()
+        if not config.preserve_db:
+            super().delete()
 
     @staticmethod
     def generate_api_key():

--- a/utils/initial_data.py
+++ b/utils/initial_data.py
@@ -170,12 +170,63 @@ untrusted-subdomain.www.mycompany.com
 
         safe_domains.save()
 
+def create_remove_old_data():
+    remove_old_data = Config.get(name='remove_old_data')
+    if remove_old_data is None:
+        remove_old_data = Config({
+            "name": "remove_old_data",
+            "description": "Automatically remove old FAME data",
+            "config": [
+                {
+                    "name": "time",
+                    "description": 'Number of days to keep FAME analyses and disabled users. If this field is empty or ≤ 0, old analyses and disabled users will be kept forever.',
+                    "type": "integer",
+                    "default": None,
+                    "value": None,
+                },
+                {
+                    "name": "preserve_db",
+                    "description": "If checked, old analyses and files will still appear on the web interface, but the actual files associated with each analysis will be deleted from disk. This includes both the original file and the ones generated during each analysis.",
+                    "type": "bool",
+                    "default": False,
+                    "value": False,
+                },
+                {
+                    "name": "keep_when_probable_name",
+                    "description": "Do not delete analyses and files automatically when a probable name was defined.",
+                    "type": "bool",
+                    "default": True,
+                    "value": True,
+                },
+                {
+                    "name": "keep_when_comment",
+                    "description": "Do not delete analyses and files automatically when a comment was entered.",
+                    "type": "bool",
+                    "default": True,
+                    "value": True,
+                },
+                {
+                    "name": "types_to_exclude",
+                    "description": "Exclude files and analyses with the following types from automatic deletion.",
+                    "type": "text",
+                    "value": None,
+                    "default": """executable
+iso
+javascript
+etc...
+""",
+                },
+            ],
+        })
+        remove_old_data.save()
+
 def create_initial_data():
     create_types()
     create_internals()
     create_safe_domains()
     create_comment_configuration()
     create_extracted_schedule()
+    create_remove_old_data()
 
 
 if __name__ == '__main__':

--- a/utils/initial_data.py
+++ b/utils/initial_data.py
@@ -170,26 +170,19 @@ untrusted-subdomain.www.mycompany.com
 
         safe_domains.save()
 
-def create_remove_old_data():
-    remove_old_data = Config.get(name='remove_old_data')
-    if remove_old_data is None:
-        remove_old_data = Config({
-            "name": "remove_old_data",
-            "description": "Automatically remove old FAME data",
+def create_cleaner():
+    cleaner = Config.get(name='cleaner')
+    if cleaner is None:
+        cleaner = Config({
+            "name": "cleaner",
+            "description": "Automatically delete old FAME files and analyses",
             "config": [
                 {
                     "name": "time",
-                    "description": 'Number of days to keep FAME analyses and disabled users. If this field is empty or ≤ 0, old analyses and disabled users will be kept forever.',
+                    "description": 'Number of days to keep FAME files and analyses. If this field is empty or ≤ 0, old files and analyses will be kept forever.',
                     "type": "integer",
                     "default": None,
                     "value": None,
-                },
-                {
-                    "name": "preserve_db",
-                    "description": "If checked, old analyses and files will still appear on the web interface, but the actual files associated with each analysis will be deleted from disk. This includes both the original file and the ones generated during each analysis.",
-                    "type": "bool",
-                    "default": False,
-                    "value": False,
                 },
                 {
                     "name": "keep_when_probable_name",
@@ -207,7 +200,7 @@ def create_remove_old_data():
                 },
                 {
                     "name": "types_to_exclude",
-                    "description": "Exclude files and analyses with the following types from automatic deletion.",
+                    "description": "Exclude files and analyses with the following type from automatic deletion.",
                     "type": "text",
                     "value": None,
                     "default": """executable
@@ -218,7 +211,7 @@ etc...
                 },
             ],
         })
-        remove_old_data.save()
+        cleaner.save()
 
 def create_initial_data():
     create_types()
@@ -226,7 +219,7 @@ def create_initial_data():
     create_safe_domains()
     create_comment_configuration()
     create_extracted_schedule()
-    create_remove_old_data()
+    create_cleaner()
 
 
 if __name__ == '__main__':

--- a/web/static/js/fame.js
+++ b/web/static/js/fame.js
@@ -246,6 +246,24 @@ function enable_autorefresh_switch() {
   });
 }
 
+function enable_delete_file() {
+  $('#main-content').on('click', 'a#file-delete', function (e) {
+    e.preventDefault();
+
+    if (confirm("This will delete the file and its associated analyses. Do you really want to proceed?")) {
+      url = $(this).attr('href');
+      $.ajax({
+        url: url,
+        method: 'DELETE'
+      }).done(function (data) {
+        window.location.href = '../';
+      }).fail(function (data) {
+        window.location.href = '../';
+      });
+    }
+  });
+}
+
 $(function () {
   $('#file-field').fileinput({
     browseClass: "btn btn-info btn-fill",
@@ -264,5 +282,6 @@ $(function () {
   enable_ioc_submission();
   enable_av_submission();
   enable_confirm_dialogs();
+  enable_delete_file();
   enable_autorefresh_switch();
 });

--- a/web/static/js/fame.js
+++ b/web/static/js/fame.js
@@ -250,15 +250,14 @@ function enable_delete_file() {
   $('#main-content').on('click', 'a#file-delete', function (e) {
     e.preventDefault();
 
-    if (confirm("This will delete the file and its associated analyses. Do you really want to proceed?")) {
-      url = $(this).attr('href');
+    url = $(this).attr('href');
+    warn = "This will delete the actual file and analyses support files (images, etc..) from disk, but the FAME analyses/file will remain in the web interface. Do you really want to proceed?";
+    if (confirm(warn)) {
       $.ajax({
         url: url,
         method: 'DELETE'
       }).done(function (data) {
-        window.location.href = '../';
-      }).fail(function (data) {
-        window.location.href = '../';
+        window.location.reload();
       });
     }
   });

--- a/web/templates/files/details.html
+++ b/web/templates/files/details.html
@@ -100,8 +100,8 @@
                                 <li><a href="{{ url_for('FilesView:download', id=file._id) }}"><i class="pe-7s-cloud-download"></i> Download</a></li>
                             {% endif %}
 
-                            {% if request.endpoint == 'FilesView:get' and current_user.has_permission('delete') %}
-                                <li><a id="file-delete" href="{{ url_for('FilesView:delete', id=file._id) }}"><i class="pe-7s-trash"></i> Delete</a></li>
+                            {% if request.endpoint == 'FilesView:get' and current_user.has_permission('delete') and file.exists_on_disk %}
+                                <li><a id="file-delete" href="{{ url_for('FilesView:anonymize', id=file._id) }}"><i class="pe-7s-trash"></i> Anonymize</a></li>
                             {% endif %}
                             {% if file.type != 'url' and file.type != 'hash' %}
                                 {% for module in av_modules %}

--- a/web/templates/files/details.html
+++ b/web/templates/files/details.html
@@ -98,7 +98,12 @@
                             {% if file.type != 'url' and file.type != 'hash' %}
 
                                 <li><a href="{{ url_for('FilesView:download', id=file._id) }}"><i class="pe-7s-cloud-download"></i> Download</a></li>
+                            {% endif %}
 
+                            {% if request.endpoint == 'FilesView:get' and current_user.has_permission('delete') %}
+                                <li><a id="file-delete" href="{{ url_for('FilesView:delete', id=file._id) }}"><i class="pe-7s-trash"></i> Delete</a></li>
+                            {% endif %}
+                            {% if file.type != 'url' and file.type != 'hash' %}
                                 {% for module in av_modules %}
                                 <li id="av-sent-{{module}}" {% if not file.antivirus[module] %}class="hidden"{% endif %} {% if file.antivirus[module] is string %}data-toggle="tooltip" data-placement="top" title="{{file.antivirus[module]}}"{% endif %}>
                                     <i class="fa fa-check text-success"></i> {{module}}

--- a/web/views/files.py
+++ b/web/views/files.py
@@ -170,6 +170,17 @@ class FilesView(FlaskView, UIView):
 
         return render_json({"file": f})
 
+    @route("/<id>", methods=["DELETE"])
+    @requires_permission("delete")
+    def delete(self, id):
+        f = File(get_or_404(current_user.files, _id=id))
+        if f:
+            f.delete(force=True)
+            flash("File {} was deleted.".format(id))
+            return {"response":"ok"}
+
+        return {"response":"File not found"}, 404
+
     def download(self, id):
         """Download the file with `id`.
 

--- a/web/views/files.py
+++ b/web/views/files.py
@@ -172,14 +172,14 @@ class FilesView(FlaskView, UIView):
 
     @route("/<id>", methods=["DELETE"])
     @requires_permission("delete")
-    def delete(self, id):
+    def anonymize(self, id):
         f = File(get_or_404(current_user.files, _id=id))
         if f:
-            f.delete(force=True)
-            flash("File {} was deleted.".format(id))
+            flash("File {} and associated analyses were deleted from disk.".format(id))
+            f.delete(preserve_db=True)
             return {"response":"ok"}
 
-        return {"response":"File not found"}, 404
+        return {"response":"File not found"}
 
     def download(self, id):
         """Download the file with `id`.

--- a/web/views/users.py
+++ b/web/views/users.py
@@ -2,6 +2,7 @@ from importlib import import_module
 from flask import request, flash, url_for, abort
 from flask_login import current_user
 from flask_classful import FlaskView, route
+from datetime import datetime
 
 from fame.common.config import fame_config
 from fame.core.user import User
@@ -177,6 +178,11 @@ class UsersView(FlaskView, UIView):
         """
         user = User(get_or_404(User.get_collection(), _id=id))
         user.update_value('enabled', False)
+        if user and 'last_activity' in user:
+            deletion_date = datetime.fromtimestamp(user['last_activity'] + 60*60*24*30).strftime("%d %B %Y")
+            flash('User was disabled and will be automatically deleted on {}'.format(deletion_date), 'danger')
+        else:
+            flash('User was disabled and will be automatically deleted within one hour', 'danger')
 
         return redirect({'user': clean_users(user)}, url_for('UsersView:index'))
 

--- a/worker.py
+++ b/worker.py
@@ -18,6 +18,7 @@ from fame.core.internals import Internals
 from fame.common.config import fame_config
 from fame.common.constants import MODULES_ROOT
 from fame.common.pip import pip_install
+from fame.common.cleaner import get_old_analyses, get_old_disabled_users
 
 
 UNIX_INSTALL_SCRIPTS = {
@@ -145,11 +146,20 @@ class Worker:
         return results
 
     # Delete files older than 7 days and empty directories
-    def clean_temp_dir(self):
+    def clean_temp_dir(self, base):
         current_time = time()
         self.last_clean = current_time
 
-        for root, dirs, files in os.walk(fame_config.temp_path, topdown=False):
+        fame_path = os.path.dirname(os.path.abspath(__file__))
+        if not fame_path in base:
+            print(
+                "WARNING: refusing to delete '{}' because it is outside of '{}'.".format(
+                    base, fame_path
+                )
+            )
+            return
+
+        for root, dirs, files in os.walk(base, topdown=False):
             for f in files:
                 filepath = os.path.join(root, f)
                 file_mtime = os.path.getmtime(filepath)
@@ -168,17 +178,35 @@ class Worker:
                 except:
                     pass
 
+    def remove_old_data(self):
+        analyses, files = get_old_analyses()
+        users = get_old_disabled_users()
+
+        for analysis in analyses:
+            analysis.delete()
+
+        for f in files:
+            f.delete()
+
+        for user in users:
+            user.delete()
+
     def start(self):
         try:
             self.last_run = time()
-            self.clean_temp_dir()
+            self.clean_temp_dir(fame_config.temp_path)
             self.update_modules()
             self.process = self._new_celery_worker()
 
             while True:
                 updates = Internals.get(name='updates')
                 if time() > (self.last_clean + 3600):
-                    self.clean_temp_dir()
+                    self.clean_temp_dir(fame_config.temp_path)
+                    if fame_config.remote:
+                        self.clean_temp_dir(fame_config.storage_path)
+
+                    if 'updates' in self.queues:
+                        self.remove_old_data()
 
                 if updates['last_update'] > self.last_run:
                     # Stop running worker

--- a/worker.py
+++ b/worker.py
@@ -178,17 +178,20 @@ class Worker:
                 except:
                     pass
 
-    def remove_old_data(self):
+    def run_cleaner(self):
         analyses, files = get_old_analyses()
         users = get_old_disabled_users()
 
         for analysis in analyses:
+            print('Cleaner: Deleting analysis {}'.format(analysis['_id']))
             analysis.delete()
 
         for f in files:
+            print('Cleaner: Deleting file {}'.format(f['_id']))
             f.delete()
 
         for user in users:
+            print('Cleaner: Deleting user {}'.format(user['_id']))
             user.delete()
 
     def start(self):
@@ -206,7 +209,7 @@ class Worker:
                         self.clean_temp_dir(fame_config.storage_path)
 
                     if 'updates' in self.queues:
-                        self.remove_old_data()
+                        self.run_cleaner()
 
                 if updates['last_update'] > self.last_run:
                     # Stop running worker


### PR DESCRIPTION
This PR implements a way to delete automatically disabled users after 30 days (based on their last activity time) and old analyses/files (based on a configurable time). 

Also, this PR adds an option to "anonymize" a file and its analyses from the web interface. To "anonymize" means here to keep analyses in the database, but to delete the actual file from disk as well as analyse's support files, if any. 

Close https://github.com/certsocietegenerale/fame/issues/17