### PR TITLE
Fix for 403 error when Fame behind proxy.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -223,6 +223,7 @@ Create the file `/etc/nginx/sites-available/fame` with the following contents::
         location / {
           proxy_pass http://127.0.0.1:4200;
           proxy_set_header X-Forwarded-For $remote_addr;
+          proxy_set_header Host $http_host;
         }
 
         location /static/ {

--- a/web/views/helpers.py
+++ b/web/views/helpers.py
@@ -175,7 +175,7 @@ def csrf_protect():
     if request.method not in ('GET', 'HEAD', 'OPTIONS', 'TRACE'):
         referer = request.headers.get('Referer')
 
-        if referer is None or different_origin(referer, get_fame_url):
+        if referer is None or different_origin(referer, get_fame_url()):
             raise Forbidden(description="Referer check failed.")
 
 

--- a/web/views/helpers.py
+++ b/web/views/helpers.py
@@ -175,7 +175,7 @@ def csrf_protect():
     if request.method not in ('GET', 'HEAD', 'OPTIONS', 'TRACE'):
         referer = request.headers.get('Referer')
 
-        if referer is None or different_origin(referer, request.url_root):
+        if referer is None or different_origin(referer, get_fame_url):
             raise Forbidden(description="Referer check failed.")
 
 


### PR DESCRIPTION
CSRF protect function need check fame urls from config.
When proxy is used need forwarding host header.