### PR TITLE
ad auth: Fix incorrect set operation

### DIFF
--- a/web/auth/ad/user_management.py
+++ b/web/auth/ad/user_management.py
@@ -95,7 +95,7 @@ def get_mapping(collection, name):
     result = set()
     for source_group in collection:
         for mapping in ROLE_MAPPING.get(source_group, {}).get(name, []):
-            result.update(mapping)
+            result.add(mapping)
     return list(result)
 
 


### PR DESCRIPTION
This is a bug fix for user group mapping when using AD login. `mapping` is of type `str`, so using `update` puts single characters into the set, which is quite undesirable.