### PR TITLE
Make sure deactivation date is in the future when disabling a user

### DIFF
--- a/utils/install.py
+++ b/utils/install.py
@@ -62,7 +62,7 @@ def define_mongo_connection(context):
 
     try:
         mongo = MongoClient(context['mongo_host'], context['mongo_port'], serverSelectionTimeoutMS=10000)
-        mongo.server_info()
+        mongo.admin.command('ping')
         db = mongo[context['mongo_db']]
     except Exception as e:
         print(e)

--- a/utils/troubleshoot.py
+++ b/utils/troubleshoot.py
@@ -58,7 +58,6 @@ def mongodb():
                 authSource="fame")
             db = mongo[fame_config.mongo_db]
 
-        print(("Version: {}".format(connection.server_info()['version'])))
         print(("Authorization check: {}\n".format(test_mongodb_connection(db))))
         return True
     except Exception as e:

--- a/web/views/users.py
+++ b/web/views/users.py
@@ -178,9 +178,14 @@ class UsersView(FlaskView, UIView):
         """
         user = User(get_or_404(User.get_collection(), _id=id))
         user.update_value('enabled', False)
+
+        deletion_date = datetime.fromtimestamp(0)
         if user and 'last_activity' in user:
-            deletion_date = datetime.fromtimestamp(user['last_activity'] + 60*60*24*30).strftime("%d %B %Y")
-            flash('User was disabled and will be automatically deleted on {}'.format(deletion_date), 'danger')
+            deletion_date = datetime.fromtimestamp(user['last_activity'])
+
+        if deletion_date > datetime.now():
+            deletion_date += 60 * 60 * 24 * 30
+            flash(f'User was disabled and will be automatically deleted on {deletion_date.strftime("%d %B %Y")}', 'danger')
         else:
             flash('User was disabled and will be automatically deleted within one hour', 'danger')
 


### PR DESCRIPTION
This PR fixes a GUI issue sometimes showing deactivation dates of users in the past
Also, this PR allows FAME to work with MongoDB 8.2, which requires authentication to read server info