### PR TITLE
Add ability to delete files from FAME entirely

### DIFF
--- a/fame/core/module_dispatcher.py
+++ b/fame/core/module_dispatcher.py
@@ -46,7 +46,7 @@ class ModuleDispatcher(object):
             ('add_probable_name', "Allows user to set an object's probable name"),
             ('see_logs', 'Allows user to access the log section of anlyses. This could reveal information on the underlying system.'),
             ('review', 'Allows user to review analyses. This is reserved to users analyzing submissions.'),
-            ('delete', 'Allows user to anonymize (soft-delete) files and associated analyses.'),
+            ('delete', 'Allows user to anonymize (soft-delete) and hard-delete files and associated analyses.'),
         ])
 
         self.load_all_modules()

--- a/web/static/js/fame.js
+++ b/web/static/js/fame.js
@@ -252,7 +252,7 @@ function enable_autorefresh_switch() {
 }
 
 function enable_delete_file() {
-  $('#main-content').on('click', 'a#file-delete', function (e) {
+  $('#main-content').on('click', 'a#file-delete-from-disk', function (e) {
     e.preventDefault();
 
     url = $(this).attr('href');
@@ -263,6 +263,21 @@ function enable_delete_file() {
         method: 'DELETE'
       }).done(function (data) {
         window.location.reload();
+      });
+    }
+  });
+
+  $('#main-content').on('click', 'a#file-delete-entirely', function (e) {
+    e.preventDefault();
+
+    url = $(this).attr('href');
+    warn = "This will delete all information/analyses for this file from FAME. Do you really want to proceed?";
+    if (confirm(warn)) {
+      $.ajax({
+        url: url,
+        method: 'DELETE'
+      }).done(function (data) {
+        window.location.href = "../../files/";
       });
     }
   });

--- a/web/templates/files/details.html
+++ b/web/templates/files/details.html
@@ -101,7 +101,10 @@
                             {% endif %}
 
                             {% if request.endpoint == 'FilesView:get' and current_user.has_permission('delete') and file.exists_on_disk %}
-                                <li><a id="file-delete" href="{{ url_for('FilesView:anonymize', id=file._id) }}"><i class="pe-7s-trash"></i> Anonymize</a></li>
+                                <li><a id="file-delete-from-disk" href="{{ url_for('FilesView:anonymize', id=file._id) }}"><i class="pe-7s-lock"></i> Anonymize</a></li>
+                            {% endif %}
+                            {% if request.endpoint == 'FilesView:get' and current_user.has_permission('delete') %}
+                                <li><a id="file-delete-entirely" href="{{ url_for('FilesView:delete', id=file._id) }}"><i class="pe-7s-trash"></i> Delete</a></li>
                             {% endif %}
                             {% if file.type != 'url' and file.type != 'hash' %}
                                 {% for module in av_modules %}

--- a/web/views/files.py
+++ b/web/views/files.py
@@ -192,6 +192,25 @@ class FilesView(FlaskView, UIView):
 
         return {"response": "File not found"}
 
+    @route("/<id>/delete", methods=["DELETE"])
+    @requires_permission("delete")
+    def delete(self, id):
+        """Completely deletes a file from FAME, including all analyses.
+
+        .. :quickref: File; Delete an object.
+
+        :param id: id of the file to delete.
+
+        :>json string response: Contain information on the deletion status.
+        """
+        f = File(get_or_404(current_user.files, _id=id))
+        if f:
+            flash("File {} and associated analyses were deleted.".format(id))
+            f.delete(preserve_db=False)
+            return {"response": "ok"}
+
+        return {"response": "File not found"}
+
     def download(self, id):
         """Download the file with `id`.
 


### PR DESCRIPTION
We have a requirement to delete analysis information related to cases upon closing the case. FAME only supported this through database calls so far, so I added a button.

* Change icon for Anonymize to `lock` for better differentiation
* Add new `files/<id>/delete` route for hard-deleting

This won't cancel (actual) running analyses, but from what I could determine it should not be a huge problem. Their database update calls will simply fail silently in most cases, and the whole thing will fizzle out. New support files will be rejected in remote workers; in local workers they could cause some littering. We don't use local workers, but I suppose adding a simple does-my-analysis-exist check there would solve this.